### PR TITLE
Process unfinished jobs

### DIFF
--- a/do_llh_inFoV4realtime2.py
+++ b/do_llh_inFoV4realtime2.py
@@ -529,9 +529,9 @@ def analysis_for_imxy_square(imx0, imx1, imy0, imy1, bkg_bf_params_list,\
             t0 = tbins0[i]
             t1 = tbins1[i]
             dt = t1 - t0
-            sig_llh_obj.set_time(tbins0[i], tbins1[i])
             
             sig_bkg_mod.set_bkg_params(bkg_bf_params_list[i])
+            sig_llh_obj.set_time(tbins0[i], tbins1[i])
             
 #             for pname,val in bkg_bf_params_list[i].items():
 #                 pars_[bkg_name+'_'+pname] = val

--- a/do_llh_inFoV4realtime2.py
+++ b/do_llh_inFoV4realtime2.py
@@ -482,7 +482,7 @@ def analysis_for_imxy_square(imx0, imx1, imy0, imy1, bkg_bf_params_list,\
 #                     parss_[bkg_name+'_'+pname] = val
 #                 sig_miner.set_fixed_params(list(parss_.keys()), values=list(parss_.values()))
                 
-                sig_bkg_mod.set_bkg_params(bkg_bf_params_list[0])
+                sig_bkg_mod.set_bkg_params(bkg_bf_params_list[i])
 
                 t0 = tbins0[i]
                 t1 = tbins1[i]
@@ -623,7 +623,7 @@ def analysis_for_imxy_square(imx0, imx1, imy0, imy1, bkg_bf_params_list,\
     
     
 
-@profile
+#@profile
 def do_analysis(proc_num, square_tab, ev_data, flux_mod, rt_dir,\
                 ebins0, ebins1, bl_dmask,\
                 trigger_time, work_dir,\

--- a/do_llh_outFoV4realtime2.py
+++ b/do_llh_outFoV4realtime2.py
@@ -34,7 +34,7 @@ from LLH import LLH_webins
 from models import CompoundModel, Point_Source_Model_Binned_Rates,\
                     Bkg_Model_wFlatA, Source_Model_InFoV, Source_Model_InOutFoV
 from coord_conv_funcs import theta_phi2imxy, imxy2theta_phi
-
+from do_manage2 import get_out_res_fnames
 
 # need to read rate fits from DB
 # and read twinds
@@ -270,7 +270,7 @@ def analysis_at_theta_phi(theta, phi, rt_obj, bkg_bf_params_list, bkg_mod,\
 def do_analysis(proc_num, seed_tab, ev_data, flux_mod, rt_dir,\
                 ebins0, ebins1, bl_dmask,\
                 trigger_time, work_dir,\
-                bkg_fname):
+                bkg_fname, ignore_started=False):
 
     started_dname = os.path.join(work_dir,'started_outfov')
 
@@ -319,9 +319,15 @@ def do_analysis(proc_num, seed_tab, ev_data, flux_mod, rt_dir,\
         already_started = False
         if fname0 in fnames:
             already_started = True
-        if already_started:
+        if already_started and not ignore_started:
             logging.info("Already started")
             continue
+        save_fname = 'res_hpind_%d_.csv' %(hp_ind)
+        fnames = get_out_res_fnames()
+        if save_fname in fnames:
+            logging.info("Already has results")
+            continue
+
 
         f = open(fname, 'w')
         f.write('NONE')
@@ -467,6 +473,15 @@ def main(args):
 						trigtime, work_dir, args.bkg_fname)
 
 
+    seed_tab_shuff = seed_tab.sample(frac=1)
+
+    for i in range(Njobs):
+        if i == proc_num:
+            continue
+        do_analysis(i, seed_tab_shuff, ev_data, flux_mod, rt_dir,\
+                        ebins0, ebins1, bl_dmask,\
+                        trigtime, work_dir, args.bkg_fname,\
+                        ignore_started=True)
 
 
 if __name__ == "__main__":

--- a/do_manage2.py
+++ b/do_manage2.py
@@ -113,6 +113,9 @@ def cli():
     parser.add_argument('--pbs_rhel7_fname', type=str,\
             help="Name of pbs script",\
             default='/storage/work/jjd330/local/bat_data/BatML/submission_scripts/pyscript_template_rhel7.pbs')
+    parser.add_argument('--pbs_arr_fname', type=str,\
+            help="Name of pbs script",\
+            default='/storage/home/jjd330/work/local/NITRATES/submission_scripts/pyscript_template_array.pbs')
     parser.add_argument('--min_pc', type=float,\
             help="Min partical coding fraction to use",\
             default=0.1)
@@ -800,7 +803,7 @@ def get_ssh_client(server, retries=5):
 
 def sub_jobs(njobs, name, pyscript, pbs_fname, queue='open',\
                 workdir=None, qos=None, q=None, ssh=True, extra_args=None,\
-                ppn=1, rhel7=False):
+                ppn=1, rhel7=False, array=True):
 
     hostname = socket.gethostname()
 
@@ -863,6 +866,23 @@ def sub_jobs(njobs, name, pyscript, pbs_fname, queue='open',\
     cmds = []
     jobids = []
 
+    if array and not ssh:
+        if njobs > 1:
+            cmd_ = 'workdir=%s,njobs=%d,pyscript=%s,extra_args="%s" -t 0-%d' %(workdir,njobs,pyscript,extra_args,njobs-1)
+        else:
+            cmd_ = 'workdir=%s,njobs=%d,pyscript=%s,extra_args="%s"' %(workdir,njobs,pyscript,extra_args)
+        cmd = base_sub_cmd + cmd_
+        logging.info("Trying to submit: ")
+        logging.info(cmd)
+
+        try:
+            os.system(cmd)
+            # subprocess.check_call(cmd, shell=True)
+        except Exception as E:
+            logging.error(E)
+            logging.error("Messed up with ")
+            logging.error(cmd)
+        return
     for i in range(njobs):
 
         # cmd_ = 'jobid=%d,workdir=%s,njobs=%d,pyscript=%s' %(i,workdir,njobs,pyscript)
@@ -1113,29 +1133,19 @@ def main(args):
     # just set this to 16 for now
     Nratejobs = 24
 
+    pbs_script = args.pbs_arr_fname
 
     if args.do_bkg:
         logging.info("Submitting bkg estimation job now")
         # try:
         if args.archive:
             extra_args = "--archive --twind %.3f"%(args.twind)
-            if args.rhel7:
-                sub_jobs(1, 'BKG_'+args.GWname, args.BKGpyscript,\
-                        args.pbs_rhel7_fname, queue=args.queue, ppn=4,\
-                        extra_args=extra_args, qos=None, rhel7=args.rhel7, q=args.q)
-            else:
-                sub_jobs(1, 'BKG_'+args.GWname, args.BKGpyscript,\
-                        args.pbs_fname, queue=args.queue, ppn=4,\
+            sub_jobs(1, 'BKG_'+args.GWname, args.BKGpyscript,\
+                        pbs_script, queue=args.queue, ppn=4,\
                         extra_args=extra_args, qos=None, rhel7=args.rhel7, q=args.q)
         else:
-            if args.rhel7:
-                sub_jobs(1, 'BKG_'+args.GWname, args.BKGpyscript,\
-                        args.pbs_rhel7_fname, queue=args.queue,\
-                        ppn=4, qos=None, rhel7=args.rhel7, q=args.q)
-            else:
-                sub_jobs(1, 'BKG_'+args.GWname, args.BKGpyscript,\
-                        args.pbs_fname,\
-                        queue=args.queue,\
+            sub_jobs(1, 'BKG_'+args.GWname, args.BKGpyscript,\
+                        pbs_script, queue=args.queue,\
                         ppn=4, qos=None, rhel7=args.rhel7, q=args.q)
         logging.info("Job submitted")
         # except Exception as E:
@@ -1172,13 +1182,9 @@ def main(args):
     if args.do_rates:
         logging.info("Submitting %d rates jobs now"%(Nratejobs))
         # try:
-        if args.rhel7:
-            sub_jobs(Nratejobs, 'RATES_'+args.GWname, args.RATEpyscript,\
-                        args.pbs_rhel7_fname, queue=args.queue, qos=args.qos,\
-                        extra_args=extra_args, rhel7=args.rhel7, q=args.q)
-        else:
-            sub_jobs(Nratejobs, 'RATES_'+args.GWname, args.RATEpyscript,\
-                        args.pbs_fname, queue=args.queue, qos=args.qos,\
+        
+        sub_jobs(Nratejobs, 'RATES_'+args.GWname, args.RATEpyscript,\
+                        pbs_script, queue=args.queue, qos=args.qos,\
                         extra_args=extra_args, rhel7=args.rhel7, q=args.q)
         logging.info("Jobs submitted")
         # except Exception as E:
@@ -1336,21 +1342,12 @@ def main(args):
     # also maybe add some emails in here for progress and info and errors
     if args.do_llh:
         logging.info("Submitting %d in FoV Jobs now"%(Njobs_in))
-        if args.rhel7:
-            sub_jobs(Njobs_in, 'LLHin_'+args.GWname, args.LLHINpyscript,\
-                        args.pbs_rhel7_fname, queue=args.queue, qos=args.qos,\
+        sub_jobs(Njobs_in, 'LLHin_'+args.GWname, args.LLHINpyscript,\
+                        pbs_script, queue=args.queue, qos=args.qos,\
                         extra_args=extra_args, rhel7=args.rhel7, q=args.q)
-            logging.info("Submitting %d out of FoV Jobs now"%(Njobs_out))
-            sub_jobs(Njobs_out, 'LLHo_'+args.GWname, args.LLHOUTpyscript,\
-                        args.pbs_rhel7_fname, queue=args.queue, qos=args.qos,\
-					 	rhel7=args.rhel7, q=args.q)
-        else:
-            sub_jobs(Njobs_in, 'LLHin_'+args.GWname, args.LLHINpyscript,\
-                        args.pbs_fname, queue=args.queue, qos=args.qos,\
-                        extra_args=extra_args, rhel7=args.rhel7, q=args.q)
-            logging.info("Submitting %d out of FoV Jobs now"%(Njobs_out))
-            sub_jobs(Njobs_out, 'LLHo_'+args.GWname, args.LLHOUTpyscript,\
-                        args.pbs_fname, queue=args.queue, qos=args.qos,\
+        logging.info("Submitting %d out of FoV Jobs now"%(Njobs_out))
+        sub_jobs(Njobs_out, 'LLHo_'+args.GWname, args.LLHOUTpyscript,\
+                        pbs_script, queue=args.queue, qos=args.qos,\
 					 	rhel7=args.rhel7, q=args.q)
         logging.info("Jobs submitted, now going to monitor progress")
 

--- a/run_stuff_grb2.sh
+++ b/run_stuff_grb2.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-batml_path='/storage/work/jjd330/local/bat_data/BatML/'
+batml_path='/storage/home/jjd330/work/local/NITRATES/'
 ht_path=$batml_path'HeasoftTools/'
 sub_path=$batml_path'submission_scripts/'
 
 workdir='/gpfs/scratch/jjd330/bat_data/'
-workdir='/storage/home/j/jjd330/work/local/bat_data/realtime_workdir/'
-ratespbs='/storage/work/jjd330/local/bat_data/BatML/submission_scripts/pbs_rates_fp_realtime.pbs'
+#workdir='/storage/home/j/jjd330/work/local/bat_data/realtime_workdir/'
 
 drmdir='/storage/home/j/jjd330/work/local/bat_data/drms/'
 
@@ -34,16 +33,14 @@ export PFILES="/tmp/$$.tmp/pfiles;$HEADAS/syspfiles"
 
 trigtime=$1
 gwname=$2
-# if [ "$#" -ne 2 ]; then
-#     nimgs=$3
-# else
-#     nimgs=60
-# fi
 
-Nratejobs=16
 twind=20.0
 tmin=-20.0
 Ntdbls=6
+
+queue='jak51_b_g_bc_default'
+NinFOVjobs=260
+NoutFOVjobs=40
 
 # $Njobs=
 
@@ -80,13 +77,8 @@ cd $workdir
 
 python $batml_path'do_data_setup.py' --work_dir $workdir --trig_time $trigtime --search_twind $twind --min_dt $tmin --Ntdbls $Ntdbls --min_tbin $mintbin
 if [ -f "filter_evdata.fits" ]; then
-    # python $batml_path'do_bkg_estimation.py' > bkg_estimation_out.log 2>&1
-    # python $batml_path'do_bkg_estimation_wSA.py' --twind $twind > bkg_estimation_out.log 2>&1
-    # python $sub_path'submit_jobs.py' --Njobs $Nratejobs --workdir $workdir --name $gwname --ssh --pbs_fname $ratespbs > submit_jobs.log 2>&1 &
-    # python $sub_path'submit_jobs.py' --Njobs $Nratejobs --workdir $workdir --name $gwname --pbs_fname $ratespbs > submit_jobs.log 2>&1 &
-    # python $batml_path'do_manage.py' --Nrate_jobs $Nratejobs --GWname $gwname > manager.out 2>&1 &
     python $batml_path'do_full_rates.py' --min_tbin $mintbin > full_rates.out 2>&1 &
-    python $batml_path'do_manage2.py' --GWname $gwname --rhel7 --do_bkg --do_rates --do_llh > manager.out 2>&1 &
+    python $batml_path'do_manage2.py' --GWname $gwname --rhel7 --do_bkg --do_rates --do_llh --queue $queue --N_infov_jobs $NinFOVjobs --N_outfov_jobs $NoutFOVjobs > manager.out 2>&1 &
 fi
 
 cd $curdir

--- a/run_stuff_grb_wfiles.sh
+++ b/run_stuff_grb_wfiles.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-batml_path='/storage/work/jjd330/local/bat_data/BatML/'
+batml_path='/storage/home/jjd330/work/local/NITRATES/'
 ht_path=$batml_path'HeasoftTools/'
 sub_path=$batml_path'submission_scripts/'
 
 workdir='/gpfs/scratch/jjd330/bat_data/'
-workdir='/storage/home/j/jjd330/work/local/bat_data/realtime_workdir/'
+#workdir='/storage/home/j/jjd330/work/local/bat_data/realtime_workdir/'
 ratespbs='/storage/work/jjd330/local/bat_data/BatML/submission_scripts/pbs_rates_fp_realtime.pbs'
 
 drmdir='/storage/home/j/jjd330/work/local/bat_data/drms/'
@@ -26,12 +26,6 @@ export HEADASPROMPT=/dev/null
 
 export PFILES="/tmp/$$.tmp/pfiles;$HEADAS/syspfiles"
 
-# evfname=$1
-# dmask=$2
-# attfname=$3
-# trigtime=$4
-# gwname=$5
-
 workdir=$1
 evfname=$2
 dmask=$3
@@ -39,22 +33,15 @@ attfname=$4
 trigtime=$5
 gwname=$6
 
-
-# if [ "$#" -ne 2 ]; then
-#     nimgs=$3
-# else
-#     nimgs=60
-# fi
-
 twind=20.0
 tmin=-20.0
 Ntdbls=6
 
-# $Njobs=
+queue='jak51_b_g_bc_default'
+NinFOVjobs=260
+NoutFOVjobs=40
 
-# workdir=$workdir$gwname
-# workdir=$(pwd)
-# workdir=$workdir'/'$gwname
+workdir=$workdir$gwname
 if [ ! -d "$workdir" ]; then
   mkdir $workdir
 fi
@@ -68,6 +55,7 @@ fi
 
 echo $trigtime
 echo $workdir
+echo $Nratejobs
 echo $twind
 echo $mintbin
 
@@ -86,13 +74,8 @@ cd $workdir
 
 python $batml_path'do_data_setup.py' --work_dir $workdir --trig_time $trigtime --search_twind $twind --min_dt $tmin --Ntdbls $Ntdbls --min_tbin $mintbin --evfname $evfname --dmask $dmask --att_fname $attfname --acs_fname $attfname
 if [ -f "filter_evdata.fits" ]; then
-    # python $batml_path'do_bkg_estimation.py' > bkg_estimation_out.log 2>&1
-    # python $batml_path'do_bkg_estimation_wSA.py' --twind $twind > bkg_estimation_out.log 2>&1
-    # python $sub_path'submit_jobs.py' --Njobs $Nratejobs --workdir $workdir --name $gwname --ssh --pbs_fname $ratespbs > submit_jobs.log 2>&1 &
-    # python $sub_path'submit_jobs.py' --Njobs $Nratejobs --workdir $workdir --name $gwname --pbs_fname $ratespbs > submit_jobs.log 2>&1 &
-    # python $batml_path'do_manage.py' --Nrate_jobs $Nratejobs --GWname $gwname > manager.out 2>&1 &
     python $batml_path'do_full_rates.py' --min_tbin $mintbin > full_rates.out 2>&1 &
-    python $batml_path'do_manage2.py' --GWname $gwname --do_bkg --do_rates --do_llh > manager.out 2>&1 &
+    python $batml_path'do_manage2.py' --GWname $gwname --rhel7 --do_bkg --do_rates --do_llh --queue $queue --N_infov_jobs $NinFOVjobs --N_outfov_jobs $NoutFOVjobs > manager.out 2>&1 &
 fi
 
 cd $curdir

--- a/submission_scripts/pyscript_template_array.pbs
+++ b/submission_scripts/pyscript_template_array.pbs
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+#PBS -l nodes=1:ppn=1
+#PBS -l walltime=48:00:00
+#PBS -l mem=8gb
+#PBS -l pmem=6gb
+
+echo "#-#-#Job started on `hostname` at `date` "
+echo This job runs on the following processors:
+echo `cat $PBS_NODEFILE`
+
+module load anaconda3
+# change this to whatever your env name is
+source activate py310
+
+
+# HEADAS=/storage/work/jjd330/heasoft/heasoft-6.24/x86_64-pc-linux-gnu-libc2.12
+# export HEADAS
+# . $HEADAS/headas-init.sh
+#
+# # CALDB stuff
+# CALDB=/storage/work/jjd330/caldb_files; export CALDB
+# source $CALDB/software/tools/caldbinit.sh
+#
+# export HEADASNOQUERY=
+# export HEADASPROMPT=/dev/null
+#
+# export PFILES="/tmp/$$.tmp/pfiles;$HEADAS/syspfiles"
+
+
+# change batml_path to wherever the code is 
+batml_path='/storage/home/jjd330/work/local/NITRATES/'
+ht_path=$batml_path'HeasoftTools/'
+
+export PYTHONPATH=$batml_path:$PYTHONPATH
+export PYTHONPATH=$ht_path:$PYTHONPATH
+
+echo $PBS_ARRAYID
+echo ${workdir}
+echo ${njobs}
+echo ${pyscript}
+echo ${extra_args}
+
+cd ${workdir}
+
+if [[ "$njobs" -eq 1 ]]; then
+python $batml_path${pyscript} --job_id 0 --Njobs ${njobs} ${extra_args}
+else
+python $batml_path${pyscript} --job_id $PBS_ARRAYID --Njobs ${njobs} ${extra_args}
+fi
+echo "#-#-#Job Ended at `date`"


### PR DESCRIPTION
Contains changes to -

do_llh_inFoV4realtime2.py and do_llh_outFoV4realtime2.py to process seeds that have already been started but don't have results yet, so that we don't get stuck at suspended jobs. 

do_manage2.py and new file submission_scripts/pyscript_template_array.pbs to submit jobs as an array instead of one by one to save time and simplify it. Jobs will now all have the same main ID, with an array ID attached to it that's the same as it's NITRATES job_id. 

run_stuff_grb2.sh and run_stuff_grb_wfiles.sh to just clean it up a alittle bit and make queue name and number of jobs easier to change

These changes have been tested on a full analysis and work. Nothing here can effect any of the results. 