### PR TITLE
Need an abs to not turn the low to high E ratio negative

### DIFF
--- a/nitrates/lib/gti_funcs.py
+++ b/nitrates/lib/gti_funcs.py
@@ -140,7 +140,7 @@ def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3):
     # bl_bad = (stds>10.0)&(stds2<2.5)
     bl_lowE_highSNR = stds > 10.0
     # bl_highE_lowSNR = (stds2<2.5)|((stds/stds2)>5)
-    bl_highE_lowSNR = (stds / stds2) > 3
+    bl_highE_lowSNR = (stds / np.abs(stds2)) > 3
     logging.debug("N_lowE_highSNR: " + str(np.sum(bl_lowE_highSNR)))
     if np.sum(bl_lowE_highSNR) > 0:
         logging.debug("LowE highSNRs: ")


### PR DESCRIPTION
In the selection logic for bad time intervals from low energy glitches there's a ratio of the snr at low energies to high energies to find where there is an excess at low E but not at high E. An `abs` is needed around the high energy snr to make sure the selection logic still works. 