### PR TITLE
imports the version for printing.

### DIFF
--- a/nitrates/__init__.py
+++ b/nitrates/__init__.py
@@ -13,8 +13,7 @@ __all__ = [
     "response",
 ]
 
-__version__ = "0.1a1"  # make sure this matches the setup.py
-
+from ._version import __version__
 
 from . import config
 from . import archive


### PR DESCRIPTION
This commit allows the version to be printed to the log by doing:

import nitrates as nt
`print(nt.__version__)`
