### PR TITLE
Change max counts for CR glitches from 40 to 20

### DIFF
--- a/nitrates/lib/gti_funcs.py
+++ b/nitrates/lib/gti_funcs.py
@@ -164,7 +164,7 @@ def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3):
     return bad_twinds
 
 
-def find_cr_glitch_times(ev_data, tmin, tmax, tbin_size=5e-5, emin=50, max_cnts=40):
+def find_cr_glitch_times(ev_data, tmin, tmax, tbin_size=5e-5, emin=50, max_cnts=20):
     bad_times = []
 
     t0 = tmin


### PR DESCRIPTION
Intermediate fix for too many CR glitches showing up in searches. Lowering threshold from 40 counts above 50 keV found in a single 100 microsecond bin to 20. This is still an incredibly high rate and should not effect actual signals at all. 