### PR TITLE
Incorporate switch for disabling background source location positioning

### DIFF
--- a/nitrates/_version.py
+++ b/nitrates/_version.py
@@ -1,4 +1,4 @@
 """
 This file is simply meant to define the version of the software to be used elsewhere.
 """
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/nitrates/config.py
+++ b/nitrates/config.py
@@ -14,7 +14,7 @@ if bat_data_dir is None:
     bat_data_dir = "."
 
 
-NITRATES_RESP_DIR = "/Volumes/LaCie/NITRATES_BAT_RSP_FILES/" #None # env variable can be used or this can be set
+NITRATES_RESP_DIR = "/gpfs/group/jak51/default/responses/"  # None #"/Users/tparsota/Documents/BAT_SCRIPTS/NITRATES_BAT_RSP_FILES/" # env variable can be used or this can be set
 if NITRATES_RESP_DIR is None:
     NITRATES_RESP_DIR = os.getenv("NITRATES_RESP_DIR")
 if NITRATES_RESP_DIR is None:

--- a/nitrates/config.py
+++ b/nitrates/config.py
@@ -14,7 +14,7 @@ if bat_data_dir is None:
     bat_data_dir = "."
 
 
-NITRATES_RESP_DIR = "/gpfs/group/jak51/default/responses/"  # None #"/Users/tparsota/Documents/BAT_SCRIPTS/NITRATES_BAT_RSP_FILES/" # env variable can be used or this can be set
+NITRATES_RESP_DIR = "/Volumes/LaCie/NITRATES_BAT_RSP_FILES/" #None # env variable can be used or this can be set
 if NITRATES_RESP_DIR is None:
     NITRATES_RESP_DIR = os.getenv("NITRATES_RESP_DIR")
 if NITRATES_RESP_DIR is None:

--- a/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
+++ b/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
@@ -397,7 +397,7 @@ def do_init_bkg_wPSs(
 
         ######Added here to test if we need to even do this type of operation. It doesnt seem to change the results that much. so keep this as an option for the mpi4py code
         if disable_bkg_sourcefit:
-            logging.info("Disabling the background source fitting. ")
+            logging.info("Disabling the background source location fitting. ")
             im_steps=1
             Nprocs=1
         ###################
@@ -678,6 +678,11 @@ def main(args):
         else:
             tmin_ = trigtime - 5e2
             tmax_ = trigtime + 5e2
+            
+        if args.disable_bkg_sourcefit:
+            logging.info("Disabling the background source location fitting.")
+            stop
+        
         init_bf_params, src_tab = do_init_bkg_wPSs(
             bkg_mod,
             llh_obj,

--- a/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
+++ b/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
@@ -79,7 +79,7 @@ def cli():
     )
     parser.add_argument("--disable_bkg_sourceloc_fit",
         help="Flag to tell the nitrates background estimation to not attempt to fit background sources",
-        action="store_true",
+        action="store_true"
     )
 
     args = parser.parse_args()

--- a/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
+++ b/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
@@ -681,7 +681,6 @@ def main(args):
             
         if args.disable_bkg_sourcefit:
             logging.info("Disabling the background source location fitting.")
-            stop
         
         init_bf_params, src_tab = do_init_bkg_wPSs(
             bkg_mod,
@@ -693,6 +692,7 @@ def main(args):
             Nprocs=Nprocs,
             tmin=tmin_,
             tmax=tmax_,
+            disable_bkg_sourcefit=args.disable_bkg_sourcefit
         )
 
         Nsrcs = len(src_tab)

--- a/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
+++ b/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
@@ -77,7 +77,7 @@ def cli():
         help="Flag to tell the nitrates background estimation to print logging information into a log file that may have been created prior to calling the main function",
         action="store_true",
     )
-    parser.add_argument("--disable_bkg_sourcefit",
+    parser.add_argument("--disable_bkg_sourceloc_fit",
         help="Flag to tell the nitrates background estimation to not attempt to fit background sources",
         action="store_true",
     )
@@ -327,7 +327,7 @@ def do_init_bkg_wPSs(
     TSmin=7.0,
     Nprocs=1,
     tmin=None,
-    tmax=None, disable_bkg_sourcefit=False
+    tmax=None, disable_bkg_sourceloc_fit=False
 ):
     if not tmin is None:
         bti = (-np.inf, tmin)
@@ -396,7 +396,7 @@ def do_init_bkg_wPSs(
         llh_obj.set_model(comp_mod)
 
         ######Added here to test if we need to even do this type of operation. It doesnt seem to change the results that much. so keep this as an option for the mpi4py code
-        if disable_bkg_sourcefit:
+        if disable_bkg_sourceloc_fit:
             logging.info("Disabling the background source location fitting. ")
             im_steps=1
             Nprocs=1
@@ -679,7 +679,7 @@ def main(args):
             tmin_ = trigtime - 5e2
             tmax_ = trigtime + 5e2
             
-        if args.disable_bkg_sourcefit:
+        if args.disable_bkg_sourceloc_fit:
             logging.info("Disabling the background source location fitting.")
         
         init_bf_params, src_tab = do_init_bkg_wPSs(
@@ -692,7 +692,7 @@ def main(args):
             Nprocs=Nprocs,
             tmin=tmin_,
             tmax=tmax_,
-            disable_bkg_sourcefit=args.disable_bkg_sourcefit
+            disable_bkg_sourceloc_fit=args.disable_bkg_sourceloc_fit
         )
 
         Nsrcs = len(src_tab)

--- a/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
+++ b/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
@@ -77,6 +77,10 @@ def cli():
         help="Flag to tell the nitrates background estimation to print logging information into a log file that may have been created prior to calling the main function",
         action="store_true",
     )
+    parser.add_argument("--disable_bkg_sourcefit",
+        help="Flag to tell the nitrates background estimation to not attempt to fit background sources",
+        action="store_true",
+    )
 
     args = parser.parse_args()
     return args
@@ -323,7 +327,7 @@ def do_init_bkg_wPSs(
     TSmin=7.0,
     Nprocs=1,
     tmin=None,
-    tmax=None,
+    tmax=None, disable_bkg_sourcefit=False
 ):
     if not tmin is None:
         bti = (-np.inf, tmin)
@@ -391,9 +395,10 @@ def do_init_bkg_wPSs(
 
         llh_obj.set_model(comp_mod)
 
-        ######Added here to test if we need to even do this type of operation:
-        # im_steps=1
-        # Nprocs=1
+        ######Added here to test if we need to even do this type of operation. It doesnt seem to change the results that much. so keep this as an option for the mpi4py code
+        if disable_bkg_sourcefit:
+            im_steps=1
+            Nprocs=1
         ###################
 
         bf_nllh, bf_params, TS_nulls = bkg_withPS_fit(

--- a/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
+++ b/nitrates/llh_analysis/do_bkg_estimation_wPSs_mp2.py
@@ -397,6 +397,7 @@ def do_init_bkg_wPSs(
 
         ######Added here to test if we need to even do this type of operation. It doesnt seem to change the results that much. so keep this as an option for the mpi4py code
         if disable_bkg_sourcefit:
+            logging.info("Disabling the background source fitting. ")
             im_steps=1
             Nprocs=1
         ###################


### PR DESCRIPTION
This switch allows the mpi4py version to early set the proper parameters in the do_init_bkg_wPSs function of do_bkg_estimation_wPSs_mp2.py such that the code doesn't do the source fitting, if the switch is set appropriately.

The default values for the switch is such that it will maintain the current configuration of the code where the source location is fitted in the  background fitting. 