### PR TITLE
Fix mapping of prob from flat resol map to moc

### DIFF
--- a/nitrates/lib/prob_map_funcs.py
+++ b/nitrates/lib/prob_map_funcs.py
@@ -243,8 +243,11 @@ def pmap2moc_map(prob_map, pcfname, att_row, max_bytes=2.9e6):
                         print(max_perc, mmap.uniq.nbytes)
                         mmap = mhp.HealpixMap.adaptive_moc_mesh(nside2, split_func, density=True, unit=1/u.steradian)
 
-    ras, decs = mmap.pix2ang(np.arange(len(mmap.uniq)), lonlat=True)
-    mmap[:] = hp.get_interp_val(prob_map/hp.nside2pixarea(nside), ras, decs, nest=True, lonlat=True)/u.steradian
+    for pix in range(len(mmap.data)):
+        # for each pix in moc, get integrated prob divided by solid angle of pix
+        ind0, ind1 = mmap.pix2range(nside, pix)
+        mmap[pix] = np.sum(prob_map[ind0:ind1]) / ((ind1 - ind0)*hp.nside2pixarea(nside)) / u.steradian
+
             
     return mmap
 


### PR DESCRIPTION
Instead of interpolating the full resolution probability map onto the multi-order pixels, this now goes pixel by pixel in the moc map, grabs all the full resolution pixels in that moc pixel and gets the average probability density (sum of prob of all child pixels divided by moc pixel solid angle). 
This is now fully accurate and no longer has issues with high probability pixels being mapped onto a lower resolution as the previous method did. 

This has been tested on https://guano.swift.psu.edu/trigger_report?id=748220769 which had a lot of prob in the FoV with some very high prob pixels, this resulted in needing a lower resolution map due to needing preserved information over a large fraction of the coded FoV (a lot of the coded FoV needed to maintain a finer resolution than the OFOV region) and then the interpolation poorly preserved that information and created normalization issues due to poorly preserving the information of the high prob pixels (integrated prob in FoV was reported as 1.12). 
This new method now properly preserved the information and has no normalization issues. The new skymap figure would look like this
![image](https://github.com/user-attachments/assets/c4703695-c9b9-4435-ad7c-3095a981c728)
