### PR TITLE
Add glitch BTI to GTI and GTI_SLEW

### DIFF
--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -156,6 +156,9 @@ def evfnames2write(
         logging.info(bti)
         gti_pnt = add_bti2gti(bti, gti_pnt)
         gti_pnt_hdu = fits.BinTableHDU(gti_pnt, name="GTI_POINTING")
+        gti_tot = add_bti2gti(bti, gti_tot)
+        gti_slew = add_bti2gti(bti, gti_slew)
+        gti_slew_hdu = fits.BinTableHDU(gti_pnt, name="GTI_SLEW")
 
     ev_data0 = find_and_remove_cr_glitches(ev_data0, gti_pnt)
 


### PR DESCRIPTION
Bad time intervals due to glitches were only being taken out of GTI_PNT. This now also takes them out of GTI and GTI_SLEW. 