### PR TITLE
Fix bug in adding BTIs

### DIFF
--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -154,11 +154,13 @@ def evfnames2write(
     for bti in glitch_btis:
         logging.info("Found glitch bti: ")
         logging.info(bti)
-        gti_pnt = add_bti2gti(bti, gti_pnt)
-        gti_pnt_hdu = fits.BinTableHDU(gti_pnt, name="GTI_POINTING")
+        if len(gti_pnt) >= 1:
+            gti_pnt = add_bti2gti(bti, gti_pnt)
+            gti_pnt_hdu = fits.BinTableHDU(gti_pnt, name="GTI_POINTING")
         gti_tot = add_bti2gti(bti, gti_tot)
-        gti_slew = add_bti2gti(bti, gti_slew)
-        gti_slew_hdu = fits.BinTableHDU(gti_pnt, name="GTI_SLEW")
+        if len(gti_slew) >= 1:
+            gti_slew = add_bti2gti(bti, gti_slew)
+            gti_slew_hdu = fits.BinTableHDU(gti_pnt, name="GTI_SLEW")
 
     ev_data0 = find_and_remove_cr_glitches(ev_data0, gti_pnt)
 


### PR DESCRIPTION
This threw an error if the GTI table had no rows, for example if there was no slew, then GTI_SLEW was a length 0 table and caused an error.