### PR TITLE
SVM-Based Glitch Detection and Removal

### DIFF
--- a/nitrates/config.py
+++ b/nitrates/config.py
@@ -52,6 +52,9 @@ ELEMENT_CROSS_SECTION_DNAME = os.path.join(dir, "data", "element_cross_sections"
 # Table of bright known sources from the Trans Monitor
 bright_source_table_fname = os.path.join(dir, "data", "bright_src_cat.fits")
 
+# Support Vector Model used in glitch_btis 
+SVM_model = os.path.join(dir, "data", "svm_original_model.pkl")
+
 
 EBINS0 = [15.0, 24.0, 35.0, 48.0, 64.0, 84.0, 120.0, 171.5, 245.0]
 EBINS1 = [24.0, 35.0, 48.0, 64.0, 84.0, 120.0, 171.5, 245.0, 350.0]

--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -11,6 +11,7 @@ import time
 from datetime import datetime
 import argparse
 import logging, traceback
+import pickle
 
 from ..lib.time_funcs import met2astropy, utc2met, met2utc_str, apy_time2met
 from ..lib.sqlite_funcs import (
@@ -50,6 +51,7 @@ from ..data_scraping.db_ql_funcs import get_gainoff_fname
 from ..data_scraping.api_funcs import get_sao_file
 from ..HeasoftTools.bat_tool_funcs import bateconvert
 from ..lib.search_config import Config
+from ..config import SVM_model
 
 def query_data_metslice(conn, met0, met1, table_name="SwiftQLevent"):
     sql = """SELECT * FROM %s
@@ -148,8 +150,11 @@ def evfnames2write(
     else:
         gti_tot = all_gtis[0]
 
+    with open(SVM_model, "rb") as f:
+        clf = pickle.load(f)
+
     glitch_btis = get_btis_for_glitches(
-        ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1]
+        ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1], clf
     )
     for bti in glitch_btis:
         logging.info("Found glitch bti: ")

--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -154,17 +154,21 @@ def evfnames2write(
         clf = pickle.load(f)
 
     glitch_btis = get_btis_for_glitches(
-        ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1], clf
+        ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1],
     )
-    for bti in glitch_btis:
+
+    realglitch_btis = SVM_dpi_eval(evdata, glitch_btis, clf)
+
+
+    for realglitchbti in realglitch_btis:
         logging.info("Found glitch bti: ")
-        logging.info(bti)
+        logging.info(realglitchbti)
         if len(gti_pnt) >= 1:
-            gti_pnt = add_bti2gti(bti, gti_pnt)
+            gti_pnt = add_bti2gti(realglitchbti, gti_pnt)
             gti_pnt_hdu = fits.BinTableHDU(gti_pnt, name="GTI_POINTING")
-        gti_tot = add_bti2gti(bti, gti_tot)
+        gti_tot = add_bti2gti(realglitchbti, gti_tot)
         if len(gti_slew) >= 1:
-            gti_slew = add_bti2gti(bti, gti_slew)
+            gti_slew = add_bti2gti(realglitchbti, gti_slew)
             gti_slew_hdu = fits.BinTableHDU(gti_pnt, name="GTI_SLEW")
 
     ev_data0 = find_and_remove_cr_glitches(ev_data0, gti_pnt)

--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -160,15 +160,15 @@ def evfnames2write(
     realglitch_btis = SVM_dpi_eval(evdata, glitch_btis, clf)
 
 
-    for realglitchbti in realglitch_btis:
+    for bti in realglitch_btis:
         logging.info("Found glitch bti: ")
-        logging.info(realglitchbti)
+        logging.info(bti)
         if len(gti_pnt) >= 1:
-            gti_pnt = add_bti2gti(realglitchbti, gti_pnt)
+            gti_pnt = add_bti2gti(bti, gti_pnt)
             gti_pnt_hdu = fits.BinTableHDU(gti_pnt, name="GTI_POINTING")
-        gti_tot = add_bti2gti(realglitchbti, gti_tot)
+        gti_tot = add_bti2gti(bti, gti_tot)
         if len(gti_slew) >= 1:
-            gti_slew = add_bti2gti(realglitchbti, gti_slew)
+            gti_slew = add_bti2gti(bti, gti_slew)
             gti_slew_hdu = fits.BinTableHDU(gti_pnt, name="GTI_SLEW")
 
     ev_data0 = find_and_remove_cr_glitches(ev_data0, gti_pnt)

--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -155,12 +155,11 @@ def evfnames2write(
         clf = pickle.load(f)
 
     glitch_btis = get_btis_for_glitches(
-        ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1],
+        ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1]
     )
     
     # new function added to evaluate glitches with a ML classifier
     realglitch_btis = SVM_dpi_eval(ev_data0, glitch_btis, clf)
-
 
     for bti in realglitch_btis:
         logging.info("Found glitch bti: ")

--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -46,6 +46,7 @@ from ..lib.gti_funcs import (
     get_btis_for_glitches,
     check_if_in_GTI,
     find_and_remove_cr_glitches,
+    SVM_dpi_eval,
 )
 from ..data_scraping.db_ql_funcs import get_gainoff_fname
 from ..data_scraping.api_funcs import get_sao_file
@@ -157,7 +158,7 @@ def evfnames2write(
         ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1],
     )
 
-    realglitch_btis = SVM_dpi_eval(evdata, glitch_btis, clf)
+    realglitch_btis = SVM_dpi_eval(ev_data0, glitch_btis, clf)
 
 
     for bti in realglitch_btis:

--- a/nitrates/data_prep/do_data_setup.py
+++ b/nitrates/data_prep/do_data_setup.py
@@ -157,7 +157,8 @@ def evfnames2write(
     glitch_btis = get_btis_for_glitches(
         ev_data0, gti_tot["START"][0], gti_tot["STOP"][-1],
     )
-
+    
+    # new function added to evaluate glitches with a ML classifier
     realglitch_btis = SVM_dpi_eval(ev_data0, glitch_btis, clf)
 
 

--- a/nitrates/lib/gti_funcs.py
+++ b/nitrates/lib/gti_funcs.py
@@ -1,7 +1,6 @@
 from astropy.table import Table, vstack
 import numpy as np
-import logging
-
+import logging, pickle, os
 
 def union_gtis(gti_tabs):
     """Union of overlapping time intervals.
@@ -127,7 +126,7 @@ def mk_gti_bl(times, GTI, time_pad=0.0):
     return bl
 
 
-def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3):
+def get_btis_for_glitches(evdata, tstart, tstop, clf, tbin_size=16e-3, lowE_snr_thresh=6.0, snr_ratio_thresh=2.0):
     bins = np.arange(tstart, tstop + tbin_size / 2.0, tbin_size)
     ebl = evdata["ENERGY"] <= 25.0
     ebl2 = evdata["ENERGY"] > 50.0
@@ -138,9 +137,9 @@ def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3):
     stds2 = (h2 - np.mean(h2)) / np.std(h2)
 
     # bl_bad = (stds>10.0)&(stds2<2.5)
-    bl_lowE_highSNR = stds > 10.0
+    bl_lowE_highSNR = stds > lowE_snr_thresh
     # bl_highE_lowSNR = (stds2<2.5)|((stds/stds2)>5)
-    bl_highE_lowSNR = (stds / np.abs(stds2)) > 3
+    bl_highE_lowSNR = (stds / np.abs(stds2)) > snr_ratio_thresh
     logging.debug("N_lowE_highSNR: " + str(np.sum(bl_lowE_highSNR)))
     if np.sum(bl_lowE_highSNR) > 0:
         logging.debug("LowE highSNRs: ")
@@ -156,12 +155,40 @@ def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3):
         t1 = t0 + tbin_size
 
         bad_twind = (
-            bins[:-1][bl_bad][i] - tbin_size / 2.0,
-            bins[:-1][bl_bad][i] + 1.5 * tbin_size,
+            bins[:-1][bl_bad][i] - (tbin_size / 2.0) - tbin_size,
+            bins[:-1][bl_bad][i] + (1.5 * tbin_size) + tbin_size,
         )
         bad_twinds.append(bad_twind)
 
-    return bad_twinds
+    realbad_twinds = SVM_dpi_eval(evdata, bad_twinds, clf)
+
+    return realbad_twinds
+
+def SVM_dpi_eval(evtable, possibad_twinds, clf, threshold=0.45):
+    xbins = np.arange(286 + 1) - 0.5
+    ybins = np.arange(173 + 1) - 0.5
+
+    real_bads = []
+
+    for tmin, tmax in possibad_twinds:
+        bl = (evtable['TIME'] >= tmin) & (evtable['TIME'] <= tmax)
+        binned_events = evtable[bl]
+        
+        if len(binned_events) == 0:
+            continue
+        
+        dpi = np.histogram2d(binned_events['DETX'], binned_events['DETY'], bins=[xbins, ybins])[0]
+        flatdpi = dpi.ravel().reshape(1, -1)
+
+        probabilities = clf.predict_proba(flatdpi)[0]
+        glitch_prob = probabilities[0]
+        logging.debug("Glitch probability: %.4f" % glitch_prob)
+        
+        if glitch_prob  > threshold:
+            real_bads.append((tmin, tmax))
+
+    return(real_bads)
+
 
 
 def find_cr_glitch_times(ev_data, tmin, tmax, tbin_size=5e-5, emin=50, max_cnts=20):

--- a/nitrates/lib/gti_funcs.py
+++ b/nitrates/lib/gti_funcs.py
@@ -125,8 +125,14 @@ def mk_gti_bl(times, GTI, time_pad=0.0):
         bl = bl | bl_
     return bl
 
-
+# SNR threshold editing enabled as arguments for glitch energy parameters
 def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3, lowE_snr_thresh=6.0, snr_ratio_thresh=2.0):
+    """ Finds where heat pipe glitches occur depending on SNR thresholds.
+    
+    Deafult set to lowE = 6 and the ratio = 2...algorithm was 
+    previously hard-coded 10 and 3. 
+    Returns list of possible glitch BTIS expanded to 64ms. 
+    """    
     bins = np.arange(tstart, tstop + tbin_size / 2.0, tbin_size)
     ebl = evdata["ENERGY"] <= 25.0
     ebl2 = evdata["ENERGY"] > 50.0
@@ -163,6 +169,15 @@ def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3, lowE_snr_thres
     return bad_twinds
 
 def SVM_dpi_eval(evtable, possibad_twinds, clf, threshold=0.45):
+    """ Evaluates glitch probability and returns those with >.45
+    glitch probability to the rest of the pipeline. 
+    
+    Makes a detector plane image (DPI) out of counts from 64ms of event
+    data and determines glitch pattern likelihood. 
+
+    glitch_btis greater than .45 glitch probability get returned as
+    a list of true btis as 'realglitch_btis'
+    """
     xbins = np.arange(286 + 1) - 0.5
     ybins = np.arange(173 + 1) - 0.5
 
@@ -178,6 +193,7 @@ def SVM_dpi_eval(evtable, possibad_twinds, clf, threshold=0.45):
         dpi = np.histogram2d(binned_events['DETX'], binned_events['DETY'], bins=[xbins, ybins])[0]
         flatdpi = dpi.ravel().reshape(1, -1)
 
+        # class 0 are glitches, 1 are non-glitch
         probabilities = clf.predict_proba(flatdpi)[0]
         glitch_prob = probabilities[0]
         logging.debug("Glitch probability: %.4f" % glitch_prob)

--- a/nitrates/lib/gti_funcs.py
+++ b/nitrates/lib/gti_funcs.py
@@ -126,7 +126,7 @@ def mk_gti_bl(times, GTI, time_pad=0.0):
     return bl
 
 
-def get_btis_for_glitches(evdata, tstart, tstop, clf, tbin_size=16e-3, lowE_snr_thresh=6.0, snr_ratio_thresh=2.0):
+def get_btis_for_glitches(evdata, tstart, tstop, tbin_size=16e-3, lowE_snr_thresh=6.0, snr_ratio_thresh=2.0):
     bins = np.arange(tstart, tstop + tbin_size / 2.0, tbin_size)
     ebl = evdata["ENERGY"] <= 25.0
     ebl2 = evdata["ENERGY"] > 50.0
@@ -160,9 +160,7 @@ def get_btis_for_glitches(evdata, tstart, tstop, clf, tbin_size=16e-3, lowE_snr_
         )
         bad_twinds.append(bad_twind)
 
-    realbad_twinds = SVM_dpi_eval(evdata, bad_twinds, clf)
-
-    return realbad_twinds
+    return bad_twinds
 
 def SVM_dpi_eval(evtable, possibad_twinds, clf, threshold=0.45):
     xbins = np.arange(286 + 1) - 0.5


### PR DESCRIPTION
This pull request transforms the glitch detection pipeline into a machine learning approach (with an SVM classifier) capable of finding instrumental glitches at lower S/N thresholds and removing only those with glitch likelihoods exceeding a specified threshold (set to .45).

**Key Changes**

**Added SVM glitch detection:**
- Added SVM_dpi_eval function to analyze 64ms DPI segments and flag likely glitches
- Lowered SNR candidate thresholds ((stds > 6) and (stds / np.abs(stds2)) > 2) (previously hard-coded to 10 and 3) and passed them as changeable arguments
- Glitch probabilities of candidates logged in data_setup.log
- Intervals with glitch likelihood > .45 get returned and removed from event GTI

**Interval handling:**
- Updated get_btis_for_glitches to allow customizable S/N thresholds
- t_min, t_max tuples are returned and used to update GTI with true SVM-classified btis

**Why?**
- Lowering the heat pipe glitch parameters allows the SVM to detect more glitches, which has proven effective in distinguishing these types of glitches from GRBs, SGRs, and background.
- Increased glitch rejection lowers overall noise at any S/N, improving sensitivity to GRBs in ground-based searches.
- Decreases noise from undetected glitches caused by previously strict, hard-coded glitch parameters.

**Testing:**
- The hk mask, event, and attitude pat.fits files were ran through do_data_setup.py for event obsid 00013856003 (a high-probability glitch as found by the SVM)
    - data_setup.log printed its glitch probability and returned two bad time intervals that overlapped. 
    - GTI was updated with the combined bad time interval now removed. 
- The above was repeated for an event obsid that did not return any significant glitch probability (00012872142) with initial SVM testing
    - No glitch probability was printed and entire GTI remained intact since no glitch was found. 